### PR TITLE
Notify slots when blocks are updated

### DIFF
--- a/app/models/no_cms/blocks/block.rb
+++ b/app/models/no_cms/blocks/block.rb
@@ -15,6 +15,8 @@ module NoCms::Blocks
     translates :draft
     include  NoCms::Blocks::Concerns::SerializingFields
 
+    after_save :touch_slots
+
     ##
     # In the block we get all the fields so it can accept all of them
     def fields_configuration
@@ -89,6 +91,13 @@ module NoCms::Blocks
     def to_admin_partial_path
       "#{NoCms::Blocks.admin_partials_folder}/#{self.template}"
     end
+
+    ##
+    # Notifies the block slots that the block has changed.
+    def touch_slots
+      slots.update_all(updated_at: Time.now)
+    end
+    private :touch_slots
   end
 
 end

--- a/spec/models/no_cms/blocks/blocks_slot_spec.rb
+++ b/spec/models/no_cms/blocks/blocks_slot_spec.rb
@@ -2,11 +2,21 @@ require 'spec_helper'
 
 describe NoCms::Blocks::BlockSlot do
 
+  let(:container) { build(:slotted_page, template: "default") }
+  let(:block) { build(:block, layout: "default") }
+  let(:slot) { build :block_slot, container: container , template_zone: 'body', block: block }
+
+  it "gets notified when block is updated" do
+    slot.save
+    sleep 1
+    block.save
+    expect(block.slots.first.updated_at).to_not eq slot.updated_at
+  end
+
   context "when the slot is built with a block with a wrong layout" do
 
     let(:container) { build(:slotted_page, template: 'default' ) }
     let(:block) { build(:block, layout: 'header1') }
-    let(:slot) { build :block_slot, container: container , template_zone: 'body', block: block }
 
     it "detects that the layout is not valid" do
       expect(slot).to_not be_valid


### PR DESCRIPTION
After updating a block, it touches all its slots of the update.
This allows caches to be properly refreshed after updating a block.